### PR TITLE
fix: parse stats.compilation.chunks as an array to remove deprecation warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ class NewRelicPlugin {
     }
     apply(compiler) {
         compiler.hooks.done.tapPromise('new-relic-source-map-webpack-plugin', stats => {
-            const chunks = stats.compilation.chunks;
+            const chunks = Array.from(stats.compilation.chunks);
             const assets = [];
 
             chunks


### PR DESCRIPTION
Fixes this deprecation warning:

> [DEP_WEBPACK_DEPRECATION_ARRAY_TO_SET] DeprecationWarning: Compilation.chunks was changed from Array to Set (using Array method 'map' is deprecated)