### PR TITLE
Add protection against undefined files arrays for webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ class NewRelicPlugin {
             const assets = [];
 
             chunks
-                .map(chunk => [...Array.from(chunk.files), ...Array.from(chunk.auxiliaryFiles)])
+                .map(chunk => [...Array.from(chunk.files || []), ...Array.from(chunk.auxiliaryFiles || [])])
                 .map(files => {
                     const mapRegex = /\.map(\?|$)/;
                     const fileName = files.find(file => this.extensionRegex.test(file));


### PR DESCRIPTION
For webpack 4 an error is being thrown calling `Array.from` on `chunk.auxiliaryFiles` because it is undefined in Webpack v4. This fix adds a fallback value of an empty array in case this value is undefined.